### PR TITLE
Feature/pipe 29

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -792,7 +792,8 @@ class HoudiniEngine(sgtk.platform.Engine):
         from sgtk.platform import constants
 
         return self._safe_path_join(
-            self.disk_location, constants.BUNDLE_STYLESHEET_FILE,
+            self.disk_location,
+            constants.BUNDLE_STYLESHEET_FILE,
         )
 
     def _get_engine_root_path(self):
@@ -1132,7 +1133,8 @@ class HoudiniEngine(sgtk.platform.Engine):
                     tk_houdini = self.import_module("tk_houdini")
                     base_class = tk_houdini.base_hooks.NodeHandlerBase
                     hook_instance = self.create_hook_instance(
-                        handler["hook"], base_class=base_class,
+                        handler["hook"],
+                        base_class=base_class,
                     )
                     break
             category_handler[node_type_name] = hook_instance
@@ -1231,4 +1233,4 @@ def _refresh_callback(event):
             handler = engine.node_handler(node)
             use_sgtk = node.parm("use_sgtk")
             if use_sgtk and use_sgtk.eval():
-                handler._refresh_file_path(node)
+                handler.refresh_file_path({"node": node})

--- a/hooks/node_handlers/alembic_import_handler.py
+++ b/hooks/node_handlers/alembic_import_handler.py
@@ -27,7 +27,10 @@ class AlembicImportNodeHandler(HookBaseClass):
     """
     A node handler for alembic input nodes in Houdini.
     """
+
     NODE_TYPE = "alembic"
     NODE_CATEGORY = "Sop"
 
     INPUT_PARM = "fileName"
+
+    FILECHOOSER_PATTERN = "*.abc"

--- a/hooks/node_handlers/alembicarchive_import_handler.py
+++ b/hooks/node_handlers/alembicarchive_import_handler.py
@@ -27,7 +27,10 @@ class AlembicArchiveImportNodeHandler(HookBaseClass):
     """
     A node handler for alembic input nodes in Houdini.
     """
+
     NODE_TYPE = "alembicarchive"
     NODE_CATEGORY = "Object"
 
     INPUT_PARM = "fileName"
+
+    FILECHOOSER_PATTERN = "*.abc"

--- a/hooks/node_handlers/backgroundimageplane_handler.py
+++ b/hooks/node_handlers/backgroundimageplane_handler.py
@@ -22,6 +22,8 @@ in your project configuration settings with the following inheritance:
 """
 import sgtk
 
+import hou
+
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -34,3 +36,4 @@ class BackgroundImagePlaneNodeHandler(HookBaseClass):
     NODE_CATEGORY = "Object"
 
     INPUT_PARM = "file"
+    HOU_FILE_TYPE = hou.fileType.Image

--- a/hooks/node_handlers/base_export_handler.py
+++ b/hooks/node_handlers/base_export_handler.py
@@ -125,19 +125,6 @@ class ExportNodeHandler(HookBaseClass):
         )
         parameter_group.append_template(using_next)
 
-    def _add_missing_using_next_parm(self, node):
-        """
-        Backward compatibility method to add the `sgtk_using_next_version` to
-        a node that does not currently have it.
-
-        TODO: Remove this method when we are confident that we don't need it anymore.
-
-        :param node: A :class:`hou.Node` instance.
-        """
-        parameter_group = self._get_parameter_group(node)
-        self._add_using_next_parm(node, parameter_group)
-        node.setParmTemplateGroup(parameter_group.build())
-
     def _set_up_node(self, node, parameter_group):
         """
         Set up a node for use with shotgun pipeline.
@@ -245,51 +232,6 @@ class ExportNodeHandler(HookBaseClass):
             glob_path = re.sub(re.escape(frame_spec), r"*", glob_path)
         return glob_path
 
-    def _resolve_all_versions_from_fields(self, node, fields, template):
-        """
-        Using fields and a shotgun template, get all the versions on disk
-        that relate to the current item.
-
-        :param node: A :class:`hou.Node` instance.
-        :param dict fields: The template fields.
-        :param template: An :class:`sgtk.Template`.
-
-        :rtype: list(int)
-        """
-        versions = set()
-        if fields and "name" in fields:
-            fields.setdefault("version", 1)
-            path = template.apply_fields(fields)
-            glob_path = path
-
-            version_key = template.keys.get("version")
-            if version_key:
-                format_spec = version_key.format_spec or ""
-                match = version_key._FORMAT_SPEC_RE.match(format_spec)
-                if match:
-                    pad_char = match.groups()[0]
-                    min_width = int(match.groups()[-1])
-                else:
-                    pad_char = "0"
-                    min_width = 1
-                max_pad_width = min_width - 1
-                padded_version_regex = r"%s{0,%s}\d{1,}"
-                padded_version_regex %= pad_char, max_pad_width
-                regex = r"([/_\.][vV])({})([/_\.])".format(padded_version_regex)
-                glob_path = re.sub(regex, r"\1*\3", glob_path)
-
-            glob_path = self._get_sequence_glob_path(glob_path, template, fields)
-            self.parent.logger.debug("GLOB_PATH: %s", glob_path)
-            version_paths = glob.iglob(glob_path)
-            for key, paths in itertools.groupby(version_paths, key=os.path.dirname):
-                version_path = paths.next()
-                self.parent.logger.debug("KEY: %s", key)
-                self.parent.logger.debug("VERSION_PATH: %s", version_path)
-                fields = template.validate_and_get_fields(version_path)
-                if fields:
-                    versions.add(int(fields["version"]))
-        return sorted(versions)
-
     def _resolve_version(self, all_versions, current):
         """
         From a given string, resolve the current version.
@@ -383,10 +325,6 @@ class ExportNodeHandler(HookBaseClass):
         """
         node = kwargs["node"]
         using_next_parm = node.parm(self.USING_NEXT_VERSION)
-        # TODO: remove this in time when all nodes contain using next parm
-        if not using_next_parm:
-            self._add_missing_using_next_parm(node)
-            using_next_parm = node.parm(self.USING_NEXT_VERSION)
         sgtk_version = node.parm(self.SGTK_VERSION)
         using_next = sgtk_version.evalAsString() in self.VERSION_POLICIES
         using_next_parm.set(using_next)
@@ -407,17 +345,13 @@ class ExportNodeHandler(HookBaseClass):
         self._update_template_fields(node, fields)
         self._update_optional_keys(node, template, fields)
 
-        all_versions = self._resolve_all_versions_from_fields(node, fields, template)
+        all_versions = self._resolve_all_versions_from_fields(fields, template)
         sgtk_version = node.parm(self.SGTK_VERSION)
         self._update_all_versions(node, all_versions)
 
+        using_next = sgtk_version.evalAsString() in self.VERSION_POLICIES
         using_next_parm = node.parm(self.USING_NEXT_VERSION)
-        # TODO: remove this in time when all nodes contain using next parm
-        if not using_next_parm:
-            self._add_missing_using_next_parm(node)
-            using_next = sgtk_version.evalAsString() in self.VERSION_POLICIES
-            using_next_parm = node.parm(self.USING_NEXT_VERSION)
-            using_next_parm.set(using_next)
+        using_next_parm.set(using_next)
 
         if using_next_parm.eval():
             sgtk_version.set(len(all_versions))
@@ -576,9 +510,7 @@ class ExportNodeHandler(HookBaseClass):
             if "SEQ" in fields:
                 fields["SEQ"] = "FORMAT: $F"
             current_version = fields.get("version", self.NEXT_VERSION_STR)
-            all_versions = self._resolve_all_versions_from_fields(
-                node, fields, template
-            )
+            all_versions = self._resolve_all_versions_from_fields(fields, template)
             self._populate_from_fields(node, fields)
             self._update_all_versions(node, all_versions)
             self._set_version(node, current_version)

--- a/hooks/node_handlers/base_export_handler.py
+++ b/hooks/node_handlers/base_export_handler.py
@@ -257,6 +257,7 @@ class ExportNodeHandler(HookBaseClass):
         :param node: A :class:`hou.Node` instance.
         :param bool sgtk_enabled: The state to set the parameters to.
         """
+        super(ExportNodeHandler, self)._enable_sgtk(node, sgtk_enabled)
         output_parm = node.parm(self.OUTPUT_PARM)
         output_parm.lock(sgtk_enabled)
 

--- a/hooks/node_handlers/image_handler.py
+++ b/hooks/node_handlers/image_handler.py
@@ -22,6 +22,9 @@ in your project configuration settings with the following inheritance:
 """
 import sgtk
 
+import hou
+
+
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -34,6 +37,8 @@ class ImageNodeHandler(HookBaseClass):
     NODE_CATEGORY = "Cop2"
 
     INPUT_PARM = "filename1"
+
+    HOU_FILE_TYPE = hou.fileType.Image
 
     def _customise_parameter_group(self, node, parameter_group, sgtk_folder):
         """

--- a/hooks/node_handlers/rop_alembic_handler.py
+++ b/hooks/node_handlers/rop_alembic_handler.py
@@ -1,0 +1,36 @@
+"""Hook class to handle Houdini Alembic write nodes.
+
+Designed to inherit ``base_cache_handler`` i.e. define the ``hook`` attribute
+in your project configuration settings with the following inheritance:
+
+
+.. code-block:: yaml
+    :caption: env/includes/settings/tk-houdini_node_handlers.yml
+
+    node_handlers.shot_step:
+    - node_type: rop_alembic
+      node_category: Sop
+      hook: "{self}/node_handlers/base_export_handler.py\
+            :{self}/node_handlers/base_cache_handler.py\
+            :{self}/node_handlers/alembic_handler.py\
+            :{self}/node_handlers/rop_alembic_handler.py"
+      work_template: houdini_shot_work_alembic_cache
+      publish_template: houdini_shot_publish_alembic_cache
+      extra_args:
+        seq_work_template: houdini_shot_work_alembic_seq_cache
+        seq_publish_template: houdini_shot_publish_alembic_seq_cache
+
+"""
+import sgtk
+
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class RopAlembicNodeHandler(HookBaseClass):
+    """
+    Node handler for rop alembic export nodes in houdini.
+    """
+
+    NODE_TYPE = "rop_alembic"
+    NODE_CATEGORY = "Sop"

--- a/hooks/node_handlers/rop_geometry_handler.py
+++ b/hooks/node_handlers/rop_geometry_handler.py
@@ -1,0 +1,35 @@
+"""Hook class to handle Houdini bgeo cache read nodes.
+
+Designed to inherit ``base_cache_handler`` i.e. define the ``hook`` attribute
+in your project configuration settings with the following inheritance:
+
+.. code-block:: yaml
+    :caption: env/includes/settings/tk-houdini_node_handlers.yml
+
+    node_handlers.asset_step:
+    - node_type: geometry
+      node_category: Driver
+      hook: "{self}/node_handlers/base_export_handler.py\
+          :{self}/node_handlers/base_cache_handler.py\
+          :{self}/node_handlers/geometry_handler.py\
+          :{self}/node_handlers/rop_geometry_handler.py"
+      work_template: houdini_asset_work_cache
+      publish_template: houdini_asset_publish_cache
+      extra_args:
+        seq_work_template: houdini_asset_work_seq_cache
+        seq_publish_template: houdini_asset_publish_seq_cache
+
+"""
+import sgtk
+
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class RopGeometryNodeHandler(HookBaseClass):
+    """
+    Node handler for geometry export nodes in Houdini.
+    """
+
+    NODE_TYPE = "rop_geometry"
+    NODE_CATEGORY = "Sop"

--- a/python/tk_houdini/base_hooks/node_handler_base.py
+++ b/python/tk_houdini/base_hooks/node_handler_base.py
@@ -3,6 +3,7 @@ Implicit, base hook class for all node handlers.
 """
 
 import itertools
+import re
 
 import sgtk
 
@@ -208,7 +209,16 @@ class NodeHandlerBase(HookBaseClass):
 
         :param node: A :class:`hou.Node` instance.
         """
-        pass
+        engine_version = self.parent.version
+        folder = node.parm(self.SGTK_FOLDER)
+        folder_template = folder.parmTemplate()
+        folder_name = folder_template.folderNames()[0]
+        version_match = re.match(r"^SGTK \(ver: (.*)\)$", folder_name)
+        if version_match:
+            version = version_match.group(1)
+            if engine_version != version:
+                self.remove_sgtk_parms(node)
+                self.restore_sgtk_parms(node)
 
     def on_name_changed(self, node=None):
         """

--- a/python/tk_houdini/base_hooks/node_handler_base.py
+++ b/python/tk_houdini/base_hooks/node_handler_base.py
@@ -461,7 +461,9 @@ class NodeHandlerBase(HookBaseClass):
         :param node: A :class:`hou.Node` instance.
         :param bool sgtk_enabled: The state to set the parameters to.
         """
-        pass
+        kwargs = {"node": node}
+        if sgtk_enabled:
+            self.refresh_file_path(kwargs)
 
     def enable_sgtk(self, kwargs):
         """
@@ -471,8 +473,6 @@ class NodeHandlerBase(HookBaseClass):
         use_sgtk = node.parm(self.USE_SGTK)
         value = use_sgtk.eval()
         self._enable_sgtk(node, value)
-        if value:
-            self.refresh_file_path(kwargs)
 
     def _get_all_versions(self, node):
         """


### PR DESCRIPTION
Added two more methods to import nodes to allow the user to select the file path. As well as the original `Publish` we now have:

- `Work`: The user can select a current node and a parameter in the current scene and select from all the available versions it has generated on disk.
![image](https://user-images.githubusercontent.com/14952660/97563018-67cd3a00-19da-11eb-8693-0df6e2adbab7.png)


- `File`: The user can select any file on disk, and if it has generated multiple versions, select from them.
![image](https://user-images.githubusercontent.com/14952660/97563057-74ea2900-19da-11eb-9960-9b8c6dc905ff.png)

Also added Rop alembic and geometry handlers